### PR TITLE
Initialize session state keys for uploads

### DIFF
--- a/qualitylab/streamlit_app.py
+++ b/qualitylab/streamlit_app.py
@@ -25,6 +25,12 @@ if "exports" not in st.session_state:
     st.session_state.exports = {}
 if "rolling_window" not in st.session_state:
     st.session_state.rolling_window = 28
+if "prod_files" not in st.session_state:
+    st.session_state.prod_files = []
+if "down_files" not in st.session_state:
+    st.session_state.down_files = []
+if "plan_file" not in st.session_state:
+    st.session_state.plan_file = None
 
 # Ensure project root on path
 project_root = PROJECT_ROOT


### PR DESCRIPTION
## Summary
- ensure `prod_files`, `down_files`, and `plan_file` exist in session state at startup

## Testing
- `python -m py_compile qualitylab/*.py`
- `streamlit run qualitylab/streamlit_app.py` *(launched and exited)*

------
https://chatgpt.com/codex/tasks/task_e_6863d6803af8832bbc5d73a211fe0e2b